### PR TITLE
Add a layer.conf

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "oe-scipy"
+BBFILE_PATTERN_oe-scipy = "^${LAYERDIR}/"
+BBFILE_PRIORITY_oe-scipy = "6"
+
+LAYERDEPENDS_oe-scipy = "core"
+LAYERSERIES_COMPAT_oe-scipy = "thud"


### PR DESCRIPTION
This PR adds a `layer.conf` so this can be integrated with bitbake in a full Yocto build. This was borrowed from the @HerrMuellerluedenscheid fork of this repo.  Looks like the three of us are all trying to solve the same problem of getting scipy into Yocto. Any thoughts on how we can best centralize and share our efforts? I'm happy to discuss in the PR how you or @HerrMuellerluedenscheid feel about this.

Slightly related to this PR, we prefer @HerrMuellerluedenscheid's repo naming of `meta-scipy` which follows the standard layer naming convention. Do you have any thoughts about switching to the more standard naming convention?